### PR TITLE
change main metric because dataset is hard

### DIFF
--- a/mteb/tasks/Retrieval/BSARDRetrieval.py
+++ b/mteb/tasks/Retrieval/BSARDRetrieval.py
@@ -23,7 +23,7 @@ class BSARDRetrieval(AbsTaskRetrieval):
             "category": "s2p",
             "eval_splits": self._EVAL_SPLITS,
             "eval_langs": ["fr"],
-            "main_score": "ndcg_at_10",
+            "main_score": "ndcg_at_100",
             "revision": "5effa1b9b5fa3b0f9e12523e6e43e5f86a6e6d59",
         }
 


### PR DESCRIPTION
change main metric of BSARD : as the dataset is hard, ndcg@10 is always 0. We instead use ndcg@100