### PR TITLE
Remove BitextMining tasks from benchmark

### DIFF
--- a/scripts/run_mteb_french.py
+++ b/scripts/run_mteb_french.py
@@ -69,7 +69,6 @@ TASK_LIST = (
     + TASK_LIST_RERANKING
     + TASK_LIST_RETRIEVAL
     + TASK_LIST_STS
-    + TASK_LIST_BITEXTMINING
 )
 
 model_name = "dangvantuan/sentence-camembert-base"


### PR DESCRIPTION
Removing BitextMining tasks from the benchmark since they concern more than one language and need to be run differently (require 2 languages when calling MTEB evaluator).